### PR TITLE
changed the error handling

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -102,8 +102,8 @@ class Shoppy {
           'User-Agent': `username - localhost`
         }
       }, (err, res, body) => {
-        if (err || body.status !== 'success') {
-          reject(err || body);
+        if (err || res.statusCode !== 200) {
+          reject(err || res.statusMessage);
           return;
         }
 
@@ -128,8 +128,8 @@ class Shoppy {
           'User-Agent': `username - localhost`
         }
       }, (err, res, body) => {
-        if (err || body.status !== 'success') {
-          reject(err || body);
+        if (err || res.statusCode !== 200) {
+          reject(err || res.statusMessage);
           return;
         }
 
@@ -154,8 +154,8 @@ class Shoppy {
           'User-Agent': `username - localhost`
         }
       }, (err, res, body) => {
-        if (err || body.status !== 'success') {
-          reject(err || body);
+        if (err || res.statusCode !== 200) {
+          reject(err || res.statusMessage);
           return;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shoppy",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "wrapper for shoppy.gg",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The current error handling uses `body.status`, which doesn't exist. Instead, this PR switches to `res.statusCode`, which does exist! This was causing all requests to faile and throw unhandled rejections. 